### PR TITLE
Homechart crypto integration fixes

### DIFF
--- a/go/cryptolib/ecp256_test.go
+++ b/go/cryptolib/ecp256_test.go
@@ -3,7 +3,6 @@ package cryptolib
 import (
 	"crypto"
 	"crypto/ecdsa"
-	"encoding/base64"
 	"testing"
 
 	"github.com/candiddev/shared/go/assert"
@@ -57,10 +56,6 @@ func TestECP256(t *testing.T) {
 	assert.HasErr(t, err, nil)
 
 	err = pubStr.Verify(m, crypto.SHA256, sig)
-	assert.HasErr(t, err, nil)
-
-	b, _ := base64.StdEncoding.DecodeString("MEQCIELkh1ThrJlhYVdMlhaRG7RdZgZ/R3zCd1q2C7haDa6eAiBc8Xw+0b9blcdTlVAh6Be77aqHruiZ5fLS7U2V6e4QrA==")
-	err = pubStr.Verify(m, crypto.SHA256, b)
 	assert.HasErr(t, err, nil)
 
 	// ECDH

--- a/go/jwt/claims_test.go
+++ b/go/jwt/claims_test.go
@@ -1,0 +1,42 @@
+package jwt
+
+import (
+	"testing"
+
+	"github.com/candiddev/shared/go/assert"
+)
+
+func TestAudienceMarshalUnmarshal(t *testing.T) {
+	tests := map[string]struct {
+		input           Audience
+		wantMarshalJSON []byte
+	}{
+		"single": {
+			input: Audience{
+				"hello",
+			},
+			wantMarshalJSON: []byte(`"hello"`),
+		},
+		"double": {
+			input: Audience{
+				"hello",
+				"world",
+			},
+			wantMarshalJSON: []byte(`["hello","world"]`),
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			out, err := tc.input.MarshalJSON()
+			assert.HasErr(t, err, nil)
+			assert.Equal(t, out, tc.wantMarshalJSON)
+
+			a := Audience{}
+
+			err = a.UnmarshalJSON(out)
+			assert.HasErr(t, err, nil)
+			assert.Equal(t, a, tc.input)
+		})
+	}
+}

--- a/go/jwt/token.go
+++ b/go/jwt/token.go
@@ -44,7 +44,7 @@ const (
 // TokenHeader is a JWT header.
 type TokenHeader struct {
 	Algorithm Algorithm `json:"alg"`
-	KeyID     string    `json:"kid"`
+	KeyID     string    `json:"kid,omitempty"`
 	Type      string    `json:"typ"`
 }
 
@@ -133,7 +133,7 @@ func Parse(token string, keys cryptolib.KeysVerify) (*Token, cryptolib.KeyVerify
 	}
 
 	for i := range keys {
-		err = keys[i].Verify([]byte(strings.Join(parts[0:2], "")), header.getHash(), sig)
+		err = keys[i].Verify([]byte(strings.Join(parts[0:2], ".")), header.getHash(), sig)
 		if err == nil {
 			p = keys[i]
 
@@ -180,7 +180,7 @@ func (t *Token) GetSignMessage(a Algorithm, keyID string) (string, error) {
 
 	t.HeaderBase64 = base64.RawURLEncoding.EncodeToString(p)
 
-	return t.HeaderBase64 + t.PayloadBase64, nil
+	return t.HeaderBase64 + "." + t.PayloadBase64, nil
 }
 
 // ParsePayload parses a token payload and validates it.  Returns an error if any validation fails.

--- a/go/jwt/token_test.go
+++ b/go/jwt/token_test.go
@@ -72,7 +72,7 @@ func TestToken(t *testing.T) {
 
 			m1, _ := got1.GetSignMessage(a, prv.ID)
 			assert.Equal(t, got1.HeaderBase64 != "", true)
-			assert.Equal(t, m1, got1.HeaderBase64+got1.PayloadBase64)
+			assert.Equal(t, m1, got1.HeaderBase64+"."+got1.PayloadBase64)
 
 			assert.HasErr(t, got1.Sign(prv), nil)
 			assert.Equal(t, got1.SignatureBase64 != "", true)

--- a/go/notify/webpush_server_test.go
+++ b/go/notify/webpush_server_test.go
@@ -30,8 +30,14 @@ func TestWebPushSend(t *testing.T) {
 	srvPrv, srvPub, err := NewWebPushVAPID()
 	assert.HasErr(t, err, nil)
 
-	cliPrv, cliPub, err := NewWebPushVAPID()
+	cprv, _, err := cryptolib.NewECP256()
 	assert.HasErr(t, err, nil)
+
+	key, err := cprv.PrivateKeyECDH()
+	assert.HasErr(t, err, nil)
+
+	cliPrv := base64.RawURLEncoding.EncodeToString(key.Bytes())
+	cliPub := base64.RawURLEncoding.EncodeToString(key.PublicKey().Bytes())
 
 	msg := WebPushMessage{
 		Actions: WebPushActions{
@@ -166,7 +172,6 @@ func TestWebPushSend(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			c := WebPush{
-				BaseURL:         "hello",
 				VAPIDPublicKey:  tc.srvPub,
 				VAPIDPrivateKey: tc.srvPrv,
 			}
@@ -176,7 +181,7 @@ func TestWebPushSend(t *testing.T) {
 			m.Client = tc.client
 			resStatus = tc.resStatus
 
-			assert.HasErr(t, c.Send(ctx, &m), tc.wantErr)
+			assert.HasErr(t, c.Send(ctx, "hello", &m), tc.wantErr)
 
 			if tc.wantErr == nil {
 				assert.Equal(t, gotHeader.Get("Content-Encoding"), "aes128gcm")

--- a/shell/lib/run.sh
+++ b/shell/lib/run.sh
@@ -108,9 +108,22 @@ rpb () {
 	run-postgresql-backup
 }
 
+cmd run-postgresql-clean Run PostgreSQL clean
+run-postgresql-clean () {
+	# quoting this causes the command to break
+	# shellcheck disable=SC2086
+	echo -e "DROP OWNED BY homechart;" | ${CR} exec ${CR_EXEC_POSTGRESQL} homechart
+	# shellcheck disable=SC2086
+	echo -e "DROP OWNED BY homechart;" | ${CR} exec ${CR_EXEC_POSTGRESQL} homechart_self_hosted
+	# shellcheck disable=SC2086
+	echo -e "GRANT ALL PRIVILEGES ON DATABASE homechart TO homechart" | ${CR} exec ${CR_EXEC_POSTGRESQL} homechart
+	# shellcheck disable=SC2086
+	echo -e "GRANT ALL PRIVILEGES ON DATABASE homechart_self_hosted TO homechart" | ${CR} exec ${CR_EXEC_POSTGRESQL} homechart_self_hosted
+}
+
 cmd run-postgresql-cli,rpc Run PostgreSQL CLI
 run-postgresql-cli () {
-	run-postgresql
+	run-postgresql-start
 
 	# quoting this causes the command to break
 	# shellcheck disable=SC2086
@@ -122,7 +135,7 @@ rpc () {
 
 cmd run-postgresql-restore,rpr Run PostgreSQL restore
 run-postgresql-restore () {
-	clean-postgresql
+	run-postgresql-clean
 
 	printf "Running PostgreSQL restore..."
 	try "${CR} exec ${CR_EXEC_POSTGRESQL} < postgresql.sql"

--- a/web/src/lib/components/FormItem.css
+++ b/web/src/lib/components/FormItem.css
@@ -135,6 +135,10 @@
 	border-bottom: var(--border);
 }
 
+.FormItem__multi:not(:first-of-type) {
+	padding-top: var(--padding);
+}
+
 .FormItem__multi--disabled {
 	width: auto;
 }

--- a/web/src/lib/encryption/AES128.test.ts
+++ b/web/src/lib/encryption/AES128.test.ts
@@ -1,19 +1,19 @@
-import { aesDecrypt, aesEncrypt, NewAESKey } from "./AES";
+import { aes128GCMDecrypt, aes128GCMEncrypt, NewAES128Key } from "./AES128";
 
-test("AES", async () => {
-	const key = await NewAESKey() as string;
+test("AES128", async () => {
+	const key = await NewAES128Key() as string;
 
 	expect(key.length)
 		.toBe(Math.ceil(16/3) * 4);
 
 	const input = "testing";
 
-	let output = await aesEncrypt(key, input) as string;
+	let output = await aes128GCMEncrypt(key, input) as string;
 	expect(output)
 		.toHaveLength(Math.ceil((input.length + 12 + 4 + 12)/3) * 4); // IV + counter + append IV
 
 
-	output = await aesDecrypt(key, output) as string;
+	output = await aes128GCMDecrypt(key, output) as string;
 	expect(output)
 		.toBe(input);
 
@@ -21,15 +21,15 @@ test("AES", async () => {
 	const goKey = "9/dd0iJw0TWcg9szIWefsA==";
 	const goOutput = "tyOOaSfO6K3bx6lEVikbX7fAnIok3bu1Y9HXNPUZf3kLo3I=";
 
-	output = await aesEncrypt(goKey, input) as string;
+	output = await aes128GCMEncrypt(goKey, input) as string;
 	expect(output)
 		.toHaveLength(Math.ceil((input.length + 12 + 4 + 12)/3) * 4); // IV + counter + append IV
 
-	output = await aesDecrypt(goKey, output) as string;
+	output = await aes128GCMDecrypt(goKey, output) as string;
 	expect(output)
 		.toBe(input);
 
-	output = await aesDecrypt(goKey, goOutput) as string;
+	output = await aes128GCMDecrypt(goKey, goOutput) as string;
 	expect(output)
 		.toBe(input);
 });

--- a/web/src/lib/encryption/AES128.ts
+++ b/web/src/lib/encryption/AES128.ts
@@ -2,14 +2,14 @@ import type { Err } from "@lib/services/Log";
 import { IsErr, NewErr } from "@lib/services/Log";
 import { ArrayBufferToBase64, Base64ToArrayBuffer } from "@lib/utilities/ArrayBuffer";
 
-async function importAESKey (key: string): Promise<CryptoKey> {
+async function importAES128Key (key: string): Promise<CryptoKey> {
 	return crypto.subtle.importKey("raw", Base64ToArrayBuffer(key), "AES-GCM", true, [
 		"encrypt",
 		"decrypt",
 	]);
 }
 
-export async function NewAESKey (): Promise<string | Err> {
+export async function NewAES128Key (): Promise<string | Err> {
 	const key = await crypto.subtle.generateKey({
 		length: 128,
 		name: "AES-GCM",
@@ -32,8 +32,8 @@ export async function NewAESKey (): Promise<string | Err> {
 	return ArrayBufferToBase64(b);
 }
 
-export async function aesEncrypt (key: string, input: string): Promise<string | Err> {
-	const aes = await importAESKey(key);
+export async function aes128GCMEncrypt (key: string, input: string): Promise<string | Err> {
+	const aes = await importAES128Key(key);
 	const iv = crypto.getRandomValues(new Uint8Array(12));
 	const enc = await crypto.subtle.encrypt({
 		iv: iv,
@@ -59,8 +59,8 @@ export async function aesEncrypt (key: string, input: string): Promise<string | 
 	return ArrayBufferToBase64(output);
 }
 
-export async function aesDecrypt (key: string, input: string): Promise<string | Err> {
-	const aes = await importAESKey(key);
+export async function aes128GCMDecrypt (key: string, input: string): Promise<string | Err> {
+	const aes = await importAES128Key(key);
 	const enc = Base64ToArrayBuffer(input);
 	const iv = enc.slice(0, 12);
 	const encText = enc.slice(12);

--- a/web/src/lib/encryption/Encryption.test.ts
+++ b/web/src/lib/encryption/Encryption.test.ts
@@ -1,53 +1,83 @@
 import { IsErr } from "@lib/services/Log";
 
-import { NewAESKey } from "./AES";
-import type { EncryptedValue } from "./Encryption";
-import { EncryptionTypeAES128GCM, EncryptionTypeNone, EncryptionTypeRSA2048, EncryptValue } from "./Encryption";
-import { NewRSAKey } from "./RSA";
+import type { EncryptionType, Key, KeyType } from "./Encryption";
+import { EncryptionTypeAES128GCM, EncryptionTypeNone, EncryptionTypeRSA2048OAEP, KeyTypeAES128, KeyTypeNone, KeyTypeRSA2048Private, KeyTypeRSA2048Public, NewKey } from "./Encryption";
 
 test.each([
 	[
+		"unknown" as KeyType,
+		true,
 		EncryptionTypeNone,
 	],
 	[
+		KeyTypeNone,
+		false,
+		EncryptionTypeNone,
+	],
+	[
+		KeyTypeAES128,
+		false,
 		EncryptionTypeAES128GCM,
 	],
 	[
-		EncryptionTypeRSA2048,
+		KeyTypeRSA2048Private,
+		false,
+		EncryptionTypeRSA2048OAEP,
 	],
 	[
-		"a",
+		KeyTypeRSA2048Public,
+		false,
+		EncryptionTypeRSA2048OAEP,
 	],
-])("EncryptedValue %s", async (name) => {
-	let encryptKey = "";
-	let decryptKey = "";
+])("Key %s", async (keyType: KeyType, wantErr: boolean, wantEncryptionType: EncryptionType) => {
+	const k = await NewKey(keyType);
+	expect(IsErr(k))
+		.toBe(wantErr === true);
 
-	switch (name) {
-	case EncryptionTypeAES128GCM:
-		encryptKey = await NewAESKey() as string;
-		decryptKey = encryptKey;
-		break;
-	case EncryptionTypeRSA2048:
-		({ publicKey: encryptKey, privateKey: decryptKey } = await NewRSAKey() as {
-			privateKey: string,
-			publicKey: string,
-		});
-	}
-
-	const v = "testing123";
-
-	const ev = await EncryptValue(name, encryptKey, v) as EncryptedValue;
-
-	if (name !== "a") {
-		expect(ev.encryption)
-			.toBe(name);
-	}
-
-	if (name === "a") {
-		expect(IsErr(ev))
+	if (IsErr(k)) {
+		expect(wantErr)
 			.toBeTruthy();
 	} else {
-		expect(await ev.decrypt(decryptKey))
-			.toBe(v);
+		let decrypt: Key | undefined;
+		let encrypt: Key | undefined;
+
+		switch (keyType) {
+		case KeyTypeAES128:
+			encrypt = k.key;
+			decrypt = k.key;
+			break;
+		case KeyTypeNone:
+			encrypt = k.key;
+			decrypt = k.key;
+			break;
+		case KeyTypeRSA2048Private:
+		case KeyTypeRSA2048Public:
+			encrypt = k.publicKey;
+			decrypt = k.privateKey;
+			keyType = KeyTypeRSA2048Private; // eslint-disable-line no-param-reassign
+			break;
+		}
+
+		if (encrypt === undefined) {
+			throw"encrypt key is undefined"; // eslint-disable-line
+		} else if (decrypt === undefined) {
+			throw"decrypt key is undefined"; //eslint-disable-line
+		}
+
+		expect(decrypt.type)
+			.toBe(keyType);
+
+		const out = await encrypt.encrypt("hello");
+
+		if (IsErr(out)) {
+			expect.fail(`encrypt had error: ${out.error}`);
+		}
+
+		expect(out.keyID)
+			.toBe(encrypt.id);
+		expect(out.encryption)
+			.toBe(wantEncryptionType);
+		expect(await decrypt.decrypt(out))
+			.toBe("hello");
 	}
 });

--- a/web/src/lib/encryption/Encryption.ts
+++ b/web/src/lib/encryption/Encryption.ts
@@ -1,98 +1,212 @@
 import type { Err } from "@lib/services/Log";
 import { IsErr, NewErr } from "@lib/services/Log";
+import { ArrayBufferToBase64, ArrayBufferToString, Base64ToArrayBuffer, StringToArrayBuffer } from "@lib/utilities/ArrayBuffer";
 
-import { aesDecrypt, aesEncrypt } from "./AES";
-import { rsaDecrypt, rsaEncrypt } from "./RSA";
+import { aes128GCMDecrypt, aes128GCMEncrypt,NewAES128Key } from "./AES128";
+import { NewRSA2048Key, rsa2048OAEPDecrypt, rsa2048OAEPEncrypt } from "./RSA2048";
 
 export type EncryptionType = string; // eslint-disable-line @typescript-eslint/no-type-alias
+export type KeyType = string; // eslint-disable-line @typescript-eslint/no-type-alias
 
+export const KeyTypeAES128 = "aes128" as KeyType;
+export const KeyTypeNone = "none" as KeyType;
+export const KeyTypeRSA2048Public = "rsa2048public" as KeyType;
+export const KeyTypeRSA2048Private = "rsa2048private" as KeyType;
 export const EncryptionTypeNone = "none" as EncryptionType;
 export const EncryptionTypeAES128GCM = "aes128gcm" as EncryptionType;
-export const EncryptionTypeRSA2048 = "rsa2048" as EncryptionType;
-
-export interface EncryptedValue {
-	/** Ciphertext is the encrypted part of a value. */
-	ciphertext: string,
-
-	/** Encryption is the encryption type of a value. */
-	encryption: EncryptionType,
-}
+export const EncryptionTypeRSA2048OAEP = "rsa2048oaepsha256" as EncryptionType;
 
 export class EncryptedValue {
 	ciphertext: string;
 	encryption: EncryptionType;
+	keyID: string = "";
 
-	constructor (ciphertext: string, encryption: EncryptionType) {
+	constructor (encryption: EncryptionType, ciphertext: string, keyID: string) {
 		this.ciphertext = ciphertext;
 		this.encryption = encryption;
+		this.keyID = keyID;
 	}
 
-	async decrypt (key: string): Promise<string | Err> {
-		switch (this.encryption) {
-		case EncryptionTypeNone:
-			return this.ciphertext;
-		case EncryptionTypeAES128GCM:
-			return aesDecrypt(key, this.ciphertext);
-		case EncryptionTypeRSA2048:
-			return rsaDecrypt(key, this.ciphertext);
+	string (): string {
+		let out = `${this.encryption}:${this.ciphertext}`;
+		if (this.keyID !== "") {
+			out += `:${this.keyID}`;
 		}
+
+		return out;
+	}
+}
+
+export class Key {
+	id: string = "";
+	key: string;
+	type: KeyType;
+
+	constructor (type: KeyType, key: string, id: string) {
+		this.type = type;
+		this.id = id;
+		this.key = key;
+	}
+
+	async encrypt (input: string): Promise<EncryptedValue | Err> {
+		let c: string | Err = "";
+		let t: EncryptionType = "";
+
+		switch (this.type) {
+		case KeyTypeNone:
+			c = ArrayBufferToBase64(StringToArrayBuffer(input));
+			t = EncryptionTypeNone;
+			break;
+		case KeyTypeAES128:
+			c = await aes128GCMEncrypt(this.key, input);
+			t = EncryptionTypeAES128GCM;
+			break;
+		case KeyTypeRSA2048Public:
+			c = await rsa2048OAEPEncrypt(this.key, input);
+			t = EncryptionTypeRSA2048OAEP;
+			break;
+		}
+
+		if (IsErr(c)) {
+			return c;
+		}
+
+		if (c === "" || t === "") {
+			return NewErr("EncryptValue: unknown encryption", "Error encrypting value");
+		}
+
+		return new EncryptedValue(t, c, this.id);
+	}
+
+	async decrypt (input: EncryptedValue): Promise<string | Err> {
+		switch (input.encryption) {
+		case EncryptionTypeNone:
+			return ArrayBufferToString(Base64ToArrayBuffer(input.ciphertext));
+		case EncryptionTypeAES128GCM:
+			return aes128GCMDecrypt(this.key, input.ciphertext);
+		case EncryptionTypeRSA2048OAEP:
+			return rsa2048OAEPDecrypt(this.key, input.ciphertext);
+		}
+
 
 		return NewErr("decrypt: unknown encryption", "Error decrypting value");
 	}
 
 	string (): string {
-		return `${this.encryption}$${this.ciphertext}`;
+		let out = `${this.type}:${this.key}`;
+		if (this.id !== "") {
+			out += `:${this.id}`;
+		}
+
+		return out;
 	}
 }
 
-export function ParseEncryptedValue (s: string): EncryptedValue | Err {
-	const r = s.split("$");
+export async function NewKey (type: KeyType): Promise<({
+	key?: Key,
+	privateKey?: Key,
+	publicKey?: Key,
+} | Err)> {
+	let id = "";
+	const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+	const charactersLength = characters.length;
+	let counter = 0;
+	while (counter < 10) {
+		id += characters.charAt(Math.floor(Math.random() * charactersLength));
+		counter += 1;
+	}
+
+
+	switch (type) {
+	case KeyTypeNone:
+		return {
+			key: new Key(type, "", id),
+		};
+	case KeyTypeAES128:
+		const a = await NewAES128Key();
+		if (IsErr(a)) {
+			return a;
+		}
+
+		return {
+			key: new Key(type, a, id),
+		};
+	case KeyTypeRSA2048Private:
+	case KeyTypeRSA2048Public:
+		const r = await NewRSA2048Key();
+		if (IsErr(r)) {
+			return r;
+		}
+
+		return {
+			privateKey: new Key(KeyTypeRSA2048Private, r.privateKey, id),
+			publicKey: new Key(KeyTypeRSA2048Public, r.publicKey, id),
+		};
+	}
+
+	return NewErr("NewKey: unknown encryption", "Error generating key");
+}
+
+export function ParseEncryptedValue (value: string): EncryptedValue | Err {
+	const r = value.split(":");
 
 	let e = "";
+	let i = "";
 
-	if (r.length === 2) {
-		switch (r[0]) {
-		case EncryptionTypeNone:
-			e = EncryptionTypeNone;
-			break;
-		case EncryptionTypeAES128GCM:
-			e = EncryptionTypeAES128GCM;
-			break;
-		case EncryptionTypeRSA2048:
-			e = EncryptionTypeRSA2048;
-			break;
-		}
+	switch (r[0]) {
+	case EncryptionTypeAES128GCM:
+		e = EncryptionTypeAES128GCM;
+		break;
+	case EncryptionTypeNone:
+		e = EncryptionTypeNone;
+		break;
+	case EncryptionTypeRSA2048OAEP:
+		e = EncryptionTypeRSA2048OAEP;
+		break;
+	}
 
-		if (e !== "") {
-			return new EncryptedValue(r[1], e);
-		}
+	if (r.length === 3) {
+		i = r[2];
+	}
+
+	if (e !== "") {
+		return new EncryptedValue(e, r[1], i);
 	}
 
 	return NewErr("ParseEncryptedValue: unknown encryption", "Error reading encrypted value");
 }
 
-export async function EncryptValue (e: EncryptionType, key: string, value: string): Promise<EncryptedValue | Err> {
-	let c = "" as string | Err;
+export function ParseKey (s: string): Key | Err {
+	const r = s.split(":");
 
-	switch (e) {
-	case EncryptionTypeNone:
-		c = value;
-		break;
-	case EncryptionTypeAES128GCM:
-		c = await aesEncrypt(key, value);
-		break;
-	case EncryptionTypeRSA2048:
-		c = await rsaEncrypt(key, value);
-		break;
+	let i = "";
+	let t = "";
+
+	if (r.length === 2 || r.length === 3) {
+		switch (r[0]) {
+		case KeyTypeNone:
+			t = KeyTypeNone;
+			break;
+		case KeyTypeAES128:
+			t = KeyTypeAES128;
+			break;
+		case KeyTypeRSA2048Private:
+			t = KeyTypeRSA2048Private;
+			break;
+		case KeyTypeRSA2048Public:
+			t = KeyTypeRSA2048Public;
+			break;
+		}
+
+		if (r.length === 3) {
+			i = r[2];
+		}
+
+		if (t !== "") {
+			return new Key(t, r[1], i);
+		}
+
 	}
 
-	if (IsErr(c)) {
-		return c;
-	}
-
-	if (c !== "") {
-		return new EncryptedValue(c, e);
-	}
-
-	return NewErr("EncryptValue: unknown encryption", "Error encrypting value");
+	return NewErr("ParseKey: unknown key type", "Error reading key");
 }

--- a/web/src/lib/encryption/PBDKF2.test.ts
+++ b/web/src/lib/encryption/PBDKF2.test.ts
@@ -1,4 +1,4 @@
-import { aesDecrypt, aesEncrypt } from "@lib/encryption/AES";
+import { aes128GCMDecrypt, aes128GCMEncrypt } from "@lib/encryption/AES128";
 
 import { NewPBDKF2AES128Key } from "./PBDKF2";
 
@@ -7,6 +7,6 @@ test("PBDKF2", async () => {
 	expect(key)
 		.toBe("Zg8nzLfVZ6/wDjDFgIXWew==");
 
-	expect(await aesDecrypt(key, await aesEncrypt(key, "secret") as string))
+	expect(await aes128GCMDecrypt(key, await aes128GCMEncrypt(key, "secret") as string))
 		.toBe("secret");
 });

--- a/web/src/lib/encryption/RSA2048.test.ts
+++ b/web/src/lib/encryption/RSA2048.test.ts
@@ -1,18 +1,18 @@
-import { NewRSAKey, rsaDecrypt, rsaEncrypt } from "./RSA";
+import { NewRSA2048Key, rsa2048OAEPDecrypt, rsa2048OAEPEncrypt } from "./RSA2048";
 
-test("RSA", async () => {
-	const key = await NewRSAKey() as {
+test("RSA2048", async () => {
+	const key = await NewRSA2048Key() as {
 		privateKey: string,
 		publicKey: string,
 	};
 
 	const input = "testing";
 
-	let output = await rsaEncrypt(key.publicKey, input) as string;
+	let output = await rsa2048OAEPEncrypt(key.publicKey, input) as string;
 	expect(output)
 		.toHaveLength(344);
 
-	output = await rsaDecrypt(key.privateKey, output) as string;
+	output = await rsa2048OAEPDecrypt(key.privateKey, output) as string;
 	expect(output)
 		.toBe(input);
 
@@ -21,15 +21,15 @@ test("RSA", async () => {
 	key.publicKey = "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA1VduJ6wj3k+4zEczSb7H6rFpIHGDbtu3ZFncFmbkNshMSw6u9jLMQd7qIxbTblmkGYr98mTGus0zkbrv+iNBLzncVr8XpEF/vt9nqGK3nvBi4ip1qSRll4JyFISaWwL7tW1wke+JRpnFR/x56IcrY5AA1kJJAHF7MdEDS8c7gNyLWoSck+D3PTdODKhkVCWg63uw512/JjGW/GytqIop3P/sBvuWW703olDyhU1GyISqHbfe9uKs2Pzr6XmR+t1WD483Jft5ciCMuBA2jrgtJb4E5qEUGWUyDMK8kxyv/qkAf0tVpuEO/woO5270HHIcNjLxZrX9Ut3RpQ1UBMn30QIDAQAB";
 	const goOutput = "lvhMxKGaKzkUtZE2mhzAc6bD2qfaySflKmHC8zdLeG3kce7LiHppI/5xL4FauRZItJ/Bukb8Z3njOGGqkzu3kBEgE5PD/B5qO5odWjYDOPMc17iqJdWUm9Ifdpltokr4hsE0LnvoA6OP9ArbrOOUjt6TrNIk5mBWOz9VyUmbnEbzRqAkyYGycbTnDbLr2PTWB4vm9JxHsjd3D6C3sus9eLhvwjhTlq81QeeEn3YqfFVwXAKC4JH/sI+Ep9lh03o9tBkNHiBt7Sm/lIasLLd3u/C8dS3NgFaJXD0TzCuujVsjhorN3bR+YFIzfk8w5sT2lDURfe6Wie1ex9VRJYx2TQ==";
 
-	output = await rsaEncrypt(key.publicKey, input) as string;
+	output = await rsa2048OAEPEncrypt(key.publicKey, input) as string;
 	expect(output)
 		.toHaveLength(344);
 
-	output = await rsaDecrypt(key.privateKey, output) as string;
+	output = await rsa2048OAEPDecrypt(key.privateKey, output) as string;
 	expect(output)
 		.toBe(input);
 
-	output = await rsaDecrypt(key.privateKey, goOutput) as string;
+	output = await rsa2048OAEPDecrypt(key.privateKey, goOutput) as string;
 	expect(output)
 		.toBe(input);
 });

--- a/web/src/lib/encryption/RSA2048.ts
+++ b/web/src/lib/encryption/RSA2048.ts
@@ -2,7 +2,7 @@ import type { Err } from "@lib/services/Log";
 import { IsErr, NewErr } from "@lib/services/Log";
 import { ArrayBufferToBase64, Base64ToArrayBuffer } from "@lib/utilities/ArrayBuffer";
 
-export async function NewRSAKey (): Promise<{privateKey: string, publicKey: string,} | Err> { // eslint-disable-line jsdoc/require-jsdoc
+export async function NewRSA2048Key (): Promise<{privateKey: string, publicKey: string,} | Err> { // eslint-disable-line jsdoc/require-jsdoc
 	const key = await crypto.subtle.generateKey({
 		hash: "SHA-256",
 		modulusLength: 2048,
@@ -32,7 +32,7 @@ export async function NewRSAKey (): Promise<{privateKey: string, publicKey: stri
 	};
 }
 
-export async function importRSAKey (key: string, publicKey?: boolean): Promise<CryptoKey | Err> {
+export async function importRSA2048Key (key: string, publicKey?: boolean): Promise<CryptoKey | Err> {
 	return crypto.subtle.importKey(publicKey === true ?
 		"spki" :
 		"pkcs8", Base64ToArrayBuffer(key), {
@@ -50,8 +50,8 @@ export async function importRSAKey (key: string, publicKey?: boolean): Promise<C
 		});
 }
 
-export async function rsaEncrypt (publicKey: string, input: string): Promise<string | Err> {
-	const key = await importRSAKey(publicKey, true);
+export async function rsa2048OAEPEncrypt (publicKey: string, input: string): Promise<string | Err> {
+	const key = await importRSA2048Key(publicKey, true);
 
 	if (IsErr(key)) {
 		return key;
@@ -72,8 +72,8 @@ export async function rsaEncrypt (publicKey: string, input: string): Promise<str
 	return ArrayBufferToBase64(enc);
 }
 
-export async function rsaDecrypt (privateKey: string, input: string): Promise<string | Err> {
-	const key = await importRSAKey(privateKey);
+export async function rsa2048OAEPDecrypt (privateKey: string, input: string): Promise<string | Err> {
+	const key = await importRSA2048Key(privateKey);
 
 	if (IsErr(key)) {
 		return key;

--- a/web/src/lib/utilities/RandString.test.ts
+++ b/web/src/lib/utilities/RandString.test.ts
@@ -1,0 +1,6 @@
+import { RandString } from "./RandString";
+
+test("RandString", () => {
+	expect(RandString(10))
+		.toHaveLength(10);
+});

--- a/web/src/lib/utilities/RandString.ts
+++ b/web/src/lib/utilities/RandString.ts
@@ -1,0 +1,6 @@
+import { ArrayBufferToBase64 } from "./ArrayBuffer";
+
+export function RandString (length: number): string {
+	return ArrayBufferToBase64(crypto.getRandomValues(new Uint8Array(length)))
+		.substring(0, length);
+}


### PR DESCRIPTION
go
- fix crypto/ecp256 sign/verify not using the right function
- fix jwt not parsing Audience correctly
- fix jwt not creating a SignMessage correctly
- fix notify/webpush not working

shell
- add run-postgresql-clean to clean PostgreSQL databases
- fix run-postgresql-backup/restore not working

web
- add utilities/RandString to generate random strings
- change encryption to work with new key/encryption formats
- fix components/FormItem having unpadded borders for multi items