### PR TITLE
Etcha fixes with Rot merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A collection of stuff used by Candid Development
 
-Once upon a time, Candid Development used a monorepo and life was easy.  When we split our monorepo into product specific repos, this shared repository is the junk draw equivalent of the leftover code.  Other Candid repositories heavily use this via submodule and symlinks.
+Once upon a time, Candid Development used a monorepo and life was easy.  When we split our monorepo into product specific repos, this shared repository is the junk drawer equivalent of the leftover code.  Other Candid repositories heavily use this via submodule and symlinks.
 
 ## License
 

--- a/go/cryptolib/argon2id.go
+++ b/go/cryptolib/argon2id.go
@@ -29,7 +29,40 @@ func (*argon2ID) KDF() KDF {
 	return KDFArgon2ID
 }
 
-func (*argon2ID) EncryptKDF() (input string, key []byte, err error) {
+func (*argon2ID) KDFGet(input, keyID string) (key []byte, err error) {
+	pass, err := cli.Prompt(fmt.Sprintf("Password for %s:", keyID), "", true)
+	if err != nil {
+		return nil, err
+	}
+
+	s := strings.Split(input, "-")
+	if len(s) != 4 {
+		return nil, fmt.Errorf("unable to decode KDF input: %s", input)
+	}
+
+	salt := s[0]
+
+	time, err := strconv.Atoi(s[1])
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode KDF time: %w", err)
+	}
+
+	memory, err := strconv.Atoi(s[2])
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode KDF memory: %w", err)
+	}
+
+	l, err := strconv.Atoi(s[3])
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode KDF len: %w", err)
+	}
+
+	key = argon2.IDKey(pass[0], []byte(salt), uint32(time), uint32(memory), uint8(runtime.NumCPU()), uint32(l))
+
+	return key, nil
+}
+
+func (*argon2ID) KDFSet() (input string, key []byte, err error) {
 	pass, err := cli.Prompt("New Password (empty string skips PBKDF):", "", true)
 	if err != nil {
 		return "", nil, err
@@ -62,39 +95,6 @@ func (*argon2ID) EncryptKDF() (input string, key []byte, err error) {
 	key = argon2.IDKey(pass[0], []byte(salt), time, memory, uint8(runtime.NumCPU()), l)
 
 	return fmt.Sprintf("% s-%d-%d-%d", salt, time, memory, l), key, nil
-}
-
-func (*argon2ID) DecryptKDF(input, keyID string) (key []byte, err error) {
-	pass, err := cli.Prompt(fmt.Sprintf("Password for %s:", keyID), "", true)
-	if err != nil {
-		return nil, err
-	}
-
-	s := strings.Split(input, "-")
-	if len(s) != 4 {
-		return nil, fmt.Errorf("unable to decode KDF input: %s", input)
-	}
-
-	salt := s[0]
-
-	time, err := strconv.Atoi(s[1])
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode KDF time: %w", err)
-	}
-
-	memory, err := strconv.Atoi(s[2])
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode KDF memory: %w", err)
-	}
-
-	l, err := strconv.Atoi(s[3])
-	if err != nil {
-		return nil, fmt.Errorf("unable to decode KDF len: %w", err)
-	}
-
-	key = argon2.IDKey(pass[0], []byte(salt), uint32(time), uint32(memory), uint8(runtime.NumCPU()), uint32(l))
-
-	return key, nil
 }
 
 func (*argon2ID) Provides(Encryption) bool {

--- a/go/cryptolib/argon2id_test.go
+++ b/go/cryptolib/argon2id_test.go
@@ -16,20 +16,20 @@ func TestArgon2ID(t *testing.T) {
 
 	cli.SetStdin(p)
 
-	v1, err := EncryptKDF(Argon2ID, "", v, EncryptionAES128GCM)
+	v1, err := KDFSet(Argon2ID, "", v, EncryptionAES128GCM)
 	assert.HasErr(t, err, nil)
 	assert.Equal(t, v1.KDF, KDFArgon2ID)
 	assert.Equal(t, v1.KDFInput != "", true)
 
 	cli.SetStdin(p)
 
-	out, err := DecryptKDF(Argon2ID, v1)
+	out, err := KDFGet(Argon2ID, v1)
 	assert.HasErr(t, err, nil)
 	assert.Equal(t, out, v)
 
 	cli.SetStdin("password1234\n")
 
-	n, err := DecryptKDF(Argon2ID, v1)
+	n, err := KDFGet(Argon2ID, v1)
 	assert.HasErr(t, err, ErrDecryptingKey)
 	assert.Equal(t, string(out) != string(n), true)
 }

--- a/go/cryptolib/ecp256.go
+++ b/go/cryptolib/ecp256.go
@@ -69,10 +69,10 @@ func (ECP256PrivateKey) Algorithm() Algorithm {
 }
 
 func (e ECP256PrivateKey) DecryptAsymmetric(input EncryptedValue) ([]byte, error) {
-	return DecryptKDF(e, input)
+	return KDFGet(e, input)
 }
 
-func (e ECP256PrivateKey) DecryptKDF(input, _ string) (key []byte, err error) {
+func (e ECP256PrivateKey) KDFGet(input, _ string) (key []byte, err error) {
 	pub := ECP256PublicKey(input)
 
 	pubE, err := pub.PublicKeyECDH()
@@ -189,14 +189,14 @@ func (ECP256PublicKey) Algorithm() Algorithm {
 }
 
 func (e ECP256PublicKey) EncryptAsymmetric(input []byte, keyID string, encryption Encryption) (EncryptedValue, error) {
-	return EncryptKDF(e, keyID, input, encryption)
+	return KDFSet(e, keyID, input, encryption)
 }
 
 func (ECP256PublicKey) KDF() KDF {
 	return KDFECDHP256
 }
 
-func (e ECP256PublicKey) EncryptKDF() (input string, key []byte, err error) {
+func (e ECP256PublicKey) KDFSet() (input string, key []byte, err error) {
 	pubE, err := e.PublicKeyECDH()
 	if err != nil {
 		return "", nil, err

--- a/go/cryptolib/ed25519.go
+++ b/go/cryptolib/ed25519.go
@@ -67,10 +67,10 @@ func (Ed25519PrivateKey) Algorithm() Algorithm {
 }
 
 func (e Ed25519PrivateKey) DecryptAsymmetric(input EncryptedValue) ([]byte, error) {
-	return DecryptKDF(e, input)
+	return KDFGet(e, input)
 }
 
-func (e Ed25519PrivateKey) DecryptKDF(input, _ string) (key []byte, err error) {
+func (e Ed25519PrivateKey) KDFGet(input, _ string) (key []byte, err error) {
 	pub := Ed25519PublicKey(input)
 
 	pubE, err := pub.PublicKeyECDH()
@@ -166,14 +166,14 @@ func (Ed25519PublicKey) Algorithm() Algorithm {
 }
 
 func (e Ed25519PublicKey) EncryptAsymmetric(input []byte, keyID string, encryption Encryption) (EncryptedValue, error) {
-	return EncryptKDF(e, keyID, input, encryption)
+	return KDFSet(e, keyID, input, encryption)
 }
 
 func (Ed25519PublicKey) KDF() KDF {
 	return KDFECDHX25519
 }
 
-func (e Ed25519PublicKey) EncryptKDF() (input string, key []byte, err error) {
+func (e Ed25519PublicKey) KDFSet() (input string, key []byte, err error) {
 	pubE, err := e.PublicKeyECDH()
 	if err != nil {
 		return "", nil, err

--- a/go/cryptolib/encrypted_value.go
+++ b/go/cryptolib/encrypted_value.go
@@ -107,13 +107,13 @@ func (e EncryptedValue) Decrypt(keys []KeyProvider) ([]byte, error) {
 		// Decrypt PBKDFs
 		if e.KDF == KDFArgon2ID {
 			match = true
-			out, err = DecryptKDF(Argon2ID, e)
+			out, err = KDFGet(Argon2ID, e)
 		} else {
 			// Iterate keys
 			for i := range keys {
 				// If the key can be used as a KDF, the KDF type matches the EV (we could check KeyID stuff here, but this lets us test all available keys.  Could be inefficient, but better UX if the KeyID is changed...)
-				if d, ok := keys[i].(KeyProviderDecryptKDF); ok {
-					out, err = DecryptKDF(d, e)
+				if d, ok := keys[i].(KeyProviderKDFGet); ok {
+					out, err = KDFGet(d, e)
 
 					// End loop if we decrypted it
 					if len(out) > 0 {
@@ -130,9 +130,9 @@ func (e EncryptedValue) Decrypt(keys []KeyProvider) ([]byte, error) {
 			// If the key provides encryption, try decrypting
 			if keys[i].Provides(e.Encryption) {
 				switch t := keys[i].(type) {
-				case KeyProviderDecryptAsymmetric:
+				case KeyProviderPrivate:
 					out, err = t.DecryptAsymmetric(e)
-				case KeyProviderEncryptSymmetric:
+				case KeyProviderSymmetric:
 					out, err = t.DecryptSymmetric(e)
 				}
 			}

--- a/go/cryptolib/encrypted_value_test.go
+++ b/go/cryptolib/encrypted_value_test.go
@@ -69,8 +69,8 @@ func TestEncryptedValue(t *testing.T) {
 	assert.Equal(t, evout, ev)
 
 	// Decrypt
-	prv, pub, _ := NewKeysEncryptAsymmetric(EncryptionBest)
-	k, _ := NewKeyEncryptSymmetric(EncryptionBest)
+	prv, pub, _ := NewKeysEncryptAsymmetric(AlgorithmBest)
+	k, _ := NewKeyEncryptSymmetric(AlgorithmBest)
 	keys := []KeyProvider{
 		prv.Key,
 		pub.Key,

--- a/go/cryptolib/kdf.go
+++ b/go/cryptolib/kdf.go
@@ -14,13 +14,13 @@ var (
 	}
 )
 
-func DecryptKDF(k KeyProviderDecryptKDF, input EncryptedValue) ([]byte, error) {
-	v, err := k.DecryptKDF(input.KDFInput, input.KeyID)
+func KDFGet(k KeyProviderKDFGet, input EncryptedValue) ([]byte, error) {
+	v, err := k.KDFGet(input.KDFInput, input.KeyID)
 	if err != nil {
 		return nil, err
 	}
 
-	var key KeyProviderEncryptSymmetric
+	var key KeyProviderSymmetric
 
 	switch input.Encryption { //nolint:exhaustive
 	case EncryptionAES128GCM:
@@ -42,10 +42,10 @@ func DecryptKDF(k KeyProviderDecryptKDF, input EncryptedValue) ([]byte, error) {
 	return key.DecryptSymmetric(input)
 }
 
-func EncryptKDF(k KeyProviderEncryptKDF, keyID string, value []byte, e Encryption) (EncryptedValue, error) {
+func KDFSet(k KeyProviderKDFSet, keyID string, value []byte, e Encryption) (EncryptedValue, error) {
 	v := EncryptedValue{}
 
-	i, key, err := k.EncryptKDF()
+	i, key, err := k.KDFSet()
 	if err != nil {
 		return v, err
 	}
@@ -54,7 +54,7 @@ func EncryptKDF(k KeyProviderEncryptKDF, keyID string, value []byte, e Encryptio
 		return v, err
 	}
 
-	var ke KeyProviderEncryptSymmetric
+	var ke KeyProviderSymmetric
 
 	switch e { //nolint:exhaustive
 	case EncryptionAES128GCM:

--- a/go/cryptolib/key_test.go
+++ b/go/cryptolib/key_test.go
@@ -1,7 +1,6 @@
 package cryptolib
 
 import (
-	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -9,35 +8,35 @@ import (
 )
 
 func TestNewKeyEncryptSymmetric(t *testing.T) {
-	k, err := NewKeyEncryptSymmetric(EncryptionBest)
+	k, err := NewKeyEncryptSymmetric(AlgorithmBest)
 	assert.HasErr(t, err, nil)
 	assert.Equal(t, k.Key.Algorithm(), AlgorithmChaCha20)
 }
 
 func TestNewKeyEncryptAsymmetric(t *testing.T) {
-	prv, pub, err := NewKeysEncryptAsymmetric(EncryptionBest)
+	prv, pub, err := NewKeysEncryptAsymmetric(AlgorithmBest)
 	assert.HasErr(t, err, nil)
 	assert.Equal(t, prv.Key.Algorithm(), AlgorithmEd25519Private)
 	assert.Equal(t, pub.Key.Algorithm(), AlgorithmEd25519Public)
 }
 
 func TestParseKey(t *testing.T) {
-	aes, _ := NewKeyEncryptSymmetric(EncryptionBest)
+	aes, _ := NewKeyEncryptSymmetric(AlgorithmBest)
 
-	k, err := ParseKey[KeyProviderEncryptSymmetric](aes.String())
+	k, err := ParseKey[KeyProviderSymmetric](aes.String())
 	assert.HasErr(t, err, nil)
 	assert.Equal(t, k.ID, aes.ID)
 	assert.Equal(t, k.String(), aes.String())
 
-	_, err = ParseKey[KeyProviderEncryptAsymmetric](aes.String())
+	_, err = ParseKey[KeyProviderPrivate](aes.String())
 	assert.HasErr(t, err, ErrParseKeyNotImplemented)
 
-	_, err = ParseKey[KeyProviderEncryptAsymmetric]("hello!")
+	_, err = ParseKey[KeyProviderSymmetric]("hello!")
 	assert.HasErr(t, err, ErrParseKeyUnknown)
 }
 
 func TestKey(t *testing.T) {
-	aes, _ := NewKeyEncryptSymmetric(EncryptionBest)
+	aes, _ := NewKeyEncryptSymmetric(AlgorithmBest)
 
 	j, err := aes.MarshalText()
 	assert.HasErr(t, err, nil)
@@ -45,25 +44,31 @@ func TestKey(t *testing.T) {
 
 	assert.Equal(t, aes.String(), fmt.Sprintf("%s:%s:%s", aes.Key.Algorithm(), aes.Key, aes.ID))
 
-	k := Key[KeyProviderEncryptSymmetric]{}
+	k := Key[KeyProviderSymmetric]{}
 	k.UnmarshalText(j)
 	assert.Equal(t, k, aes)
 }
 
 func TestKeys(t *testing.T) {
-	_, v, _ := NewKeysEncryptAsymmetric(EncryptionBest)
+	_, pub1, _ := NewKeysEncryptAsymmetric(AlgorithmBest)
+	_, pub2, _ := NewKeysEncryptAsymmetric(AlgorithmBest)
 
-	k := []Key[KeyProviderEncryptAsymmetric]{
-		v,
+	k := Keys[KeyProviderPublic]{
+		pub1,
+		pub2,
 	}
 
-	j, err := json.Marshal(k)
+	bytout := []byte(fmt.Sprintf(`["%s","%s"]`, pub1.String(), pub2.String()))
+	jsonout, _ := k.MarshalJSON()
+	assert.Equal(t, jsonout, bytout)
 
-	assert.HasErr(t, err, nil)
-	assert.Equal(t, string(j), fmt.Sprintf(`["%s"]`, v.String()))
+	vout := []byte(fmt.Sprintf(`{%s,%s}`, pub1.String(), pub2.String()))
+	valout, _ := k.Value()
+	assert.Equal(t, valout.([]byte), vout)
 
-	n := []Key[KeyProviderEncryptAsymmetric]{}
+	var kout Keys[KeyProviderPublic]
 
-	assert.HasErr(t, json.Unmarshal(j, &n), nil)
-	assert.Equal(t, n, k)
+	kout.Scan(vout)
+
+	assert.Equal(t, kout, k)
 }

--- a/go/cryptolib/sig_test.go
+++ b/go/cryptolib/sig_test.go
@@ -9,47 +9,49 @@ import (
 )
 
 func TestNewSignatureVerify(t *testing.T) {
-	edprv, edpub, _ := NewKeysEncryptAsymmetric(Encryption(KDFECDHX25519))
-	ecprv, ecpub, _ := NewKeysEncryptAsymmetric(Encryption(KDFECDHP256))
-	rsprv, rspub, _ := NewKeysEncryptAsymmetric(EncryptionRSA2048OAEPSHA256)
+	edprv, edpub, _ := NewKeysEncryptAsymmetric(AlgorithmEd25519)
+	ecprv, ecpub, _ := NewKeysEncryptAsymmetric(AlgorithmECP256)
+	rsprv, rspub, _ := NewKeysEncryptAsymmetric(AlgorithmRSA2048)
 	msg := []byte("hello world")
 	tests := map[string]struct {
-		sign          KeyProviderDecryptAsymmetric
-		verify        KeyProviderEncryptAsymmetric
+		sign          Key[KeyProviderPrivate]
+		verify        Key[KeyProviderPublic]
 		wantSignErr   error
 		wantVerifyErr error
 	}{
 		"ed25519": {
-			sign:   edprv.Key,
-			verify: edpub.Key,
+			sign:   edprv,
+			verify: edpub,
 		},
 		"ecp256": {
-			sign:   ecprv.Key,
-			verify: ecpub.Key,
+			sign:   ecprv,
+			verify: ecpub,
 		},
 		"rsa": {
-			sign:   rsprv.Key,
-			verify: rspub.Key,
+			sign:   rsprv,
+			verify: rspub,
 		},
 		"wrong": {
-			sign:        Ed25519PrivateKey("hello"),
-			verify:      rspub.Key,
+			sign: Key[KeyProviderPrivate]{
+				Key: Ed25519PrivateKey("hello"),
+			},
+			verify:      rspub,
 			wantSignErr: ErrDecodingPrivateKey,
 		},
 		"mix": {
-			sign:          ecprv.Key,
-			verify:        rspub.Key,
+			sign:          ecprv,
+			verify:        rspub,
 			wantVerifyErr: ErrVerify,
 		},
 	}
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			sig, err := NewSignature(tc.sign, "123", msg)
+			sig, err := NewSignature(tc.sign, msg)
 			assert.HasErr(t, err, tc.wantSignErr)
 
 			if tc.wantSignErr == nil {
-				assert.HasErr(t, sig.Verify(msg, []KeyProviderEncryptAsymmetric{
+				assert.HasErr(t, sig.Verify(msg, Keys[KeyProviderPublic]{
 					tc.verify,
 				}), tc.wantVerifyErr)
 			}
@@ -88,9 +90,9 @@ func TestParseSignature(t *testing.T) {
 }
 
 func TestSignature(t *testing.T) {
-	prv, _, _ := NewKeysEncryptAsymmetric(EncryptionBest)
+	prv, _, _ := NewKeysEncryptAsymmetric(AlgorithmBest)
 
-	sig, _ := NewSignature(prv.Key, prv.ID, []byte("helloworld"))
+	sig, _ := NewSignature(prv, []byte("helloworld"))
 
 	// Marshal
 	strout := fmt.Sprintf("%s:%s:%s", sig.Hash, base64.StdEncoding.EncodeToString(sig.Signature), sig.KeyID)

--- a/go/jwt/token.go
+++ b/go/jwt/token.go
@@ -97,8 +97,8 @@ func New(claims CustomClaims, expiresAt time.Time, audience []string, id, issuer
 }
 
 // Parse takes a token and parses it into a Token struct for future use and the public key that verified it.  Returns an error if the signature does not match or the token format is invalid.
-func Parse(token string, keys []cryptolib.KeyProviderEncryptAsymmetric) (*Token, cryptolib.KeyProviderEncryptAsymmetric, error) {
-	var p cryptolib.KeyProviderEncryptAsymmetric
+func Parse(token string, keys cryptolib.Keys[cryptolib.KeyProviderPublic]) (*Token, cryptolib.Key[cryptolib.KeyProviderPublic], error) {
+	var p cryptolib.Key[cryptolib.KeyProviderPublic]
 
 	parts := strings.Split(token, ".")
 	if len(parts) != 3 {
@@ -133,7 +133,7 @@ func Parse(token string, keys []cryptolib.KeyProviderEncryptAsymmetric) (*Token,
 	}
 
 	for i := range keys {
-		err = keys[i].Verify([]byte(strings.Join(parts[0:2], ".")), header.getHash(), sig)
+		err = keys[i].Key.Verify([]byte(strings.Join(parts[0:2], ".")), header.getHash(), sig)
 		if err == nil {
 			p = keys[i]
 
@@ -145,7 +145,7 @@ func Parse(token string, keys []cryptolib.KeyProviderEncryptAsymmetric) (*Token,
 		return t, p, err
 	}
 
-	m, err := getSigningMethod(p.Algorithm())
+	m, err := getSigningMethod(p.Key.Algorithm())
 	if err != nil {
 		return t, p, err
 	}
@@ -254,7 +254,7 @@ func (t *Token) ParsePayload(claims CustomClaims, audRegex string, jidRegex stri
 	return claims.Valid()
 }
 
-func (t *Token) Sign(k cryptolib.Key[cryptolib.KeyProviderDecryptAsymmetric]) error {
+func (t *Token) Sign(k cryptolib.Key[cryptolib.KeyProviderPrivate]) error {
 	a, err := getSigningMethod(k.Key.Algorithm())
 	if err != nil {
 		return err

--- a/go/jwt/token_test.go
+++ b/go/jwt/token_test.go
@@ -17,8 +17,8 @@ func TestToken(t *testing.T) {
 	rsa2048prv, rsa2048pub, _ := cryptolib.NewRSA2048()
 
 	tests := map[string]struct {
-		private cryptolib.KeyProviderDecryptAsymmetric
-		public  cryptolib.KeyProviderEncryptAsymmetric
+		private cryptolib.KeyProviderPrivate
+		public  cryptolib.KeyProviderPublic
 	}{
 		"ed25519": {
 			private: ed25519prv,
@@ -38,11 +38,11 @@ func TestToken(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			e := time.Now().Add(10 * time.Second)
 
-			prv := cryptolib.Key[cryptolib.KeyProviderDecryptAsymmetric]{
+			prv := cryptolib.Key[cryptolib.KeyProviderPrivate]{
 				ID:  types.RandString(10),
 				Key: tc.private,
 			}
-			pub := cryptolib.Key[cryptolib.KeyProviderEncryptAsymmetric]{
+			pub := cryptolib.Key[cryptolib.KeyProviderPublic]{
 				ID:  types.RandString(10),
 				Key: tc.public,
 			}
@@ -73,11 +73,11 @@ func TestToken(t *testing.T) {
 			assert.HasErr(t, got1.Sign(prv), nil)
 			assert.Equal(t, got1.SignatureBase64 != "", true)
 
-			gotT1, p, err := Parse(got1.String(), []cryptolib.KeyProviderEncryptAsymmetric{
-				pub.Key,
+			gotT1, p, err := Parse(got1.String(), cryptolib.Keys[cryptolib.KeyProviderPublic]{
+				pub,
 			})
 			assert.HasErr(t, err, nil)
-			assert.Equal(t, p, pub.Key)
+			assert.Equal(t, p, pub)
 
 			jOut1 := &jwtCustom{}
 			assert.HasErr(t, gotT1.ParsePayload(jOut1, "", "", ""), nil)
@@ -95,8 +95,8 @@ func TestToken(t *testing.T) {
 			assert.HasErr(t, err, nil)
 			assert.HasErr(t, got2.Sign(prv), nil)
 
-			gotT2, _, err := Parse(got2.String(), []cryptolib.KeyProviderEncryptAsymmetric{
-				pub.Key,
+			gotT2, _, err := Parse(got2.String(), cryptolib.Keys[cryptolib.KeyProviderPublic]{
+				pub,
 			})
 			assert.HasErr(t, err, nil)
 

--- a/go/notify/webpush_server.go
+++ b/go/notify/webpush_server.go
@@ -195,7 +195,7 @@ func (c *WebPush) getJWT(baseURL, endpoint string) (string, error) {
 		return "", fmt.Errorf("error decoding private key: %w", err)
 	}
 
-	if err := t.Sign(cryptolib.Key[cryptolib.KeyProviderDecryptAsymmetric]{
+	if err := t.Sign(cryptolib.Key[cryptolib.KeyProviderPrivate]{
 		Key: cryptolib.ECP256PrivateKey(base64.StdEncoding.EncodeToString(b)),
 	}); err != nil {
 		return "", err

--- a/go/notify/webpush_server_test.go
+++ b/go/notify/webpush_server_test.go
@@ -194,8 +194,10 @@ func TestWebPushSend(t *testing.T) {
 				srvB, err := base64.RawURLEncoding.DecodeString(tc.srvPub)
 				assert.HasErr(t, err, nil)
 
-				token, _, err := jwt.Parse(strings.Split(gotHeader.Get("Authorization"), " ")[1], []cryptolib.KeyProviderEncryptAsymmetric{
-					cryptolib.ECP256PublicKey(base64.StdEncoding.EncodeToString(srvB)),
+				token, _, err := jwt.Parse(strings.Split(gotHeader.Get("Authorization"), " ")[1], cryptolib.Keys[cryptolib.KeyProviderPublic]{
+					{
+						Key: cryptolib.ECP256PublicKey(base64.StdEncoding.EncodeToString(srvB)),
+					},
 				})
 				assert.HasErr(t, err, nil)
 


### PR DESCRIPTION
go
- change cryptolib interfaces to use KeyProviderPrivate/Public, less confusing
- change cryptolib.KDFEncrypt/KDFDecrypt to KDFSet/KDFGet, less confusing
- change cryptolib.GenerateKeys to accept an optional type of key to generate
- change jwt and notify to work with new cryptolib interfaces