### PR TITLE
Set ConfigPath to consistent location

### DIFF
--- a/go/cli/cli.go
+++ b/go/cli/cli.go
@@ -143,7 +143,7 @@ Commands:
 	c := ConfigArgs{}
 
 	if !a.NoParse {
-		a.Config.CLIConfig().ConfigPath = strings.ToLower(a.Name) + ".jsonnet"
+		a.Config.CLIConfig().ConfigPath = config.FindFilenameAscending(ctx, strings.ToLower(a.Name)+".jsonnet")
 
 		flag.StringVar(&a.Config.CLIConfig().ConfigPath, "c", a.Config.CLIConfig().ConfigPath, "Path to JSON/Jsonnet configuration files separated by a comma")
 


### PR DESCRIPTION
Fixes a bug where the cli will traverse a file tree upward to locate a config to read, but it will write out any changes to the current directory, leading to duplicate config files in the tree.