### PR TITLE
Fix path resolution

### DIFF
--- a/go/cli/cli.go
+++ b/go/cli/cli.go
@@ -143,7 +143,7 @@ Commands:
 	c := ConfigArgs{}
 
 	if !a.NoParse {
-		a.Config.CLIConfig().ConfigPath = strings.ToLower(a.Name) + ".jsonnet"
+		a.Config.CLIConfig().ConfigPath = config.FindFilenameAscending(ctx, strings.ToLower(a.Name)+".jsonnet")
 
 		flag.StringVar(&a.Config.CLIConfig().ConfigPath, "c", a.Config.CLIConfig().ConfigPath, "Path to JSON/Jsonnet configuration files separated by a comma")
 

--- a/go/cli/cli_test.go
+++ b/go/cli/cli_test.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/candiddev/shared/go/assert"
@@ -52,6 +53,8 @@ func TestAppRun(t *testing.T) {
 		Name: "App",
 	}
 
+	wd, _ := os.Getwd()
+
 	tests := map[string]struct {
 		args      []string
 		buildDate string
@@ -59,6 +62,7 @@ func TestAppRun(t *testing.T) {
 		output    string
 		noParse   bool
 		run       bool
+		wantPath  string
 	}{
 		"usage": {
 			err: ErrUnknownCommand,
@@ -89,6 +93,7 @@ Flags:
   -x value
     	Set config key=value (can be provided multiple times)
 `,
+			wantPath: "app.jsonnet",
 		},
 		"config": {
 			args: []string{"-n", "-c", "./testdata/config.json", "show-config"},
@@ -96,6 +101,7 @@ Flags:
   "Show": {
     "Message": "Hello World"
   }`,
+			wantPath: filepath.Join(wd, "testdata/config.json"),
 		},
 		"world": {
 			args: []string{"-n", "-c", "./testdata/config.json", "hello", "world"},
@@ -164,6 +170,10 @@ Build Date: %s`, date),
 			assert.HasErr(t, err, tc.err)
 
 			out := logger.ReadStd()
+
+			if tc.wantPath != "" {
+				assert.Equal(t, a.Config.CLI.ConfigPath, tc.wantPath)
+			}
 
 			if tc.run {
 				assert.Equal(t, run, tc.run)

--- a/go/config/file_test.go
+++ b/go/config/file_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/candiddev/shared/go/assert"
@@ -63,4 +64,24 @@ func TestGetFile(t *testing.T) {
 
 	os.Stdin = stdin
 	os.Remove("../good.jsonnet")
+}
+
+func TestFindPathAscending(t *testing.T) {
+	ctx := context.Background()
+
+	wd, _ := os.Getwd()
+
+	tests := map[string]string{
+		"args.go":              filepath.Join(wd, "args.go"),
+		"README.md":            filepath.Join(filepath.Dir(filepath.Join(wd, "..")), "README.md"),
+		"./config.go":          filepath.Join(wd, "config.go"),
+		"./testdata/good.json": filepath.Join(wd, "testdata/good.json"),
+		"test.json":            "",
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, FindPathAscending(ctx, name), tc)
+		})
+	}
 }


### PR DESCRIPTION
go
- change FindPathAscending to be noop for multiple calls
- change cli.Run to discover paths before parsing

@nrdxp, I moved your path resolution fix to pre-parse config instead of pre-parse CLI as the value may change if someone passes `-c`.  I also made the func idempotent.